### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,8 +43,13 @@ Copy the `.env` file an create an application key
 ```
 cp .env.example .env && php artisan key:generate
 ```
+Larapi comes with Passport, included as the default authenticatin method. The Passport service provider registers its own database migration directory with the framework, so firstly you should migrate your database by running `migrate` command before running `passport:install` command. The Passport migrations will create the tables your application needs to store clients and access tokens. ( [more details on passport installation](https://laravel.com/docs/5.4/passport#installation) )
 
-Larapi comes with Passport include as the default authenticatin method. You should now install it using this command.
+```
+php artisan migrate
+``` 
+
+After running the migration, you should now install it using this command.
 
 ```
 php artisan passport:install
@@ -61,11 +66,7 @@ PASSWORD_CLIENT_SECRET=FJWQRS3PQj6atM6fz5f6AtDboo59toGplcuUYrKL
 
 If you want to save it elsewhere or change the naming be sure to modify the LoginProxy in `infrastructure/Auth/LoginProxy.php`
 
-Lastly, migrate the database tables
-
-```
-php artisan migrate
-```
+Finally,the installation has completed, ready for testing.
 
 ## Test installation
 


### PR DESCRIPTION
I would like to suggest the the change for the order of passport installation, by running migrate first, then passport:install. 
Because I got below errors, if i run passport:install first. Thank you very much for your kind sharing of knowledge and github repository
```
[Illuminate\Database\QueryException]                                         
  SQLSTATE[HY000]: General error: 1 no such table: oauth_clients (SQL: insert  
   into "oauth_clients" ("user_id", "name", "secret", "redirect", "personal_a  
  ccess_client", "password_client", "revoked", "updated_at", "created_at") va  
  lues (,  Personal Access Client, Ma93UPZSDGZL3TEtKSYEu6kmmKPREtRCEUGR5RLB,   
  http://localhost, 1, 0, 0, 2017-05-08 17:19:22, 2017-05-08 17:19:22))        
                                                                               

                                                                  
  [PDOException]                                                  
  SQLSTATE[HY000]: General error: 1 no such table: oauth_clients 
```