### PR TITLE
feat: (infrastructure) replace artisan "make" commands for namespaces

### DIFF
--- a/infrastructure/Console/ComponentMakeCommand.php
+++ b/infrastructure/Console/ComponentMakeCommand.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Infrastructure\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+class ComponentMakeCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:component {parent} {name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var Filesystem
+     */
+    protected $files;
+
+    /**
+     * All filetypes we care about per namespace
+     *
+     * @var array
+     */
+    protected $fileTypes = [
+        'Models',
+        'Controllers',
+        'Services',
+        'Repositories'
+    ];
+
+    /**
+     */
+    protected $filetype;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param Filesystem $files
+     * @param Composer $composer
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function fire()
+    {
+        $this->makeDirectory(base_path().'/api/'.$this->argument('parent'));
+
+        foreach ($this->fileTypes as $fileType) {
+            $this->makeSubDirectories(base_path().'/api/'.$this->argument('parent'), $fileType);
+            $this->makeFile($fileType);
+        }
+    }
+
+    protected function makeFile($fileType)
+    {
+        //this is the name of the stubfile, i.e. 'model.stub'
+        $stubFile = $fileType == 'Repositories' ? "repository" : strtolower(rtrim($fileType, 's'));
+        //remove ending S for filename, unless it's Models, in which case we don't like Models as an appendage to the filename
+
+        if($fileType == 'Models'){
+            $this->fileName = "";
+        } else if($fileType == 'Repositories'){
+            $this->fileName = "Repository";
+        } else {
+            $this->fileName = rtrim($fileType, 's');
+        }
+
+        $name = $this->argument('name');
+        if (!$this->files->exists(base_path() . '/api/' . $this->argument('parent') . '/' . $fileType . '/' . $name . $this->fileName . '.php')) {
+            $class = $this->buildClass($name, $stubFile, $fileType);
+            $this->files->put(base_path() . '/api/' . $this->argument('parent') . '/' . $fileType . '/' . $name . $this->fileName . '.php', $class);
+        }
+    }
+
+    /**
+     * Build the directory for the class if necessary.
+     *
+     * @param  string $path
+     * @return string
+     */
+    protected function makeDirectory($path)
+    {
+        if (!$this->files->isDirectory($path)) {
+            $this->files->makeDirectory($path, 0777, true, true);
+        }
+    }
+
+    /**
+     * Build the directory for the class if necessary.
+     *
+     * @param  string $path
+     * @return string
+     */
+    protected function makeSubDirectories($path, $fileType)
+    {
+        if ($this->files->isDirectory($path)) {
+            $this->makeDirectory($path.'/'.$fileType.'/');
+        }
+    }
+
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function getModelPath($name)
+    {
+        $name = str_replace($this->getAppNamespace(), '', $name);
+
+        return $this->laravel['path'] . '/' . str_replace('\\', '/', $name) . '.php';
+    }
+
+
+    protected function buildClass($name,$type,$fileType)
+    {
+        $stub = $this->files->get($this->getStub($type));
+        return $this->replaceNamespace($stub, $name,  $fileType)->replaceClass($stub, $name);
+    }
+
+    /**
+     * Replace the class name for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $name
+     * @return string
+     */
+    protected function replaceClass($stub, $name)
+    {
+        $filename = $this->fileName;
+        $class = str_replace($this->getNamespace($name).'\\', '', $name);
+
+        $stub = str_replace('DummyVariable', $class, $stub);
+        $stub = str_replace('dummyVariable', lcfirst($class), $stub);
+
+        return str_replace('DummyClass', $class.$filename, $stub);
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub($type)
+    {
+        return __DIR__.'/stubs/'.$type.'.stub';
+    }
+
+    /**
+     * Replace the namespace for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $name
+     * @return $this
+     */
+    protected function replaceNamespace(&$stub, $name, $fileType)
+    {
+
+        $stub = str_replace('DummyNamespace','Api\\'.$this->argument('parent').'\\'.$fileType, $stub);
+        $stub = str_replace('DummyPath','Api\\'.$this->argument('parent'), $stub);
+
+        return $this;
+    }
+
+    /**
+     * Get the full namespace for a given class, without the class name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getNamespace($name)
+    {
+        return trim(implode('\\', array_slice(explode('\\', $name), 0, -1)), '\\');
+    }
+
+    public function handle()
+    {
+        $this->fire();
+    }
+}

--- a/infrastructure/Console/Kernel.php
+++ b/infrastructure/Console/Kernel.php
@@ -14,7 +14,8 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        AddUserCommand::class
+        AddUserCommand::class,
+        ComponentMakeCommand::class,
     ];
 
     /**

--- a/infrastructure/Console/stubs/controller.stub
+++ b/infrastructure/Console/stubs/controller.stub
@@ -1,0 +1,84 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyPath\Models\DummyVariable;
+use DummyPath\Services\DummyVariableService;
+use Illuminate\Http\Request;
+use Infrastructure\Http\Controller;
+
+class DummyClass extends Controller
+{
+    public $dummyVariableService;
+
+    public function __construct
+        (
+            DummyVariableService $dummyVariableService
+        )
+        {
+            $this->dummyVariableService = $dummyVariableService;
+        }
+    
+        public function getAll()
+        {
+            $resourceOptions = $this->parseResourceOptions();
+    
+            $data = $this->dummyVariableService->getAll($resourceOptions, true);
+            $parsedData = $this->parseData($data, $resourceOptions );
+    
+            return $this->response($parsedData);
+        }
+    
+        public function getById($dummyVariableId)
+        {
+            $resourceOptions = $this->parseResourceOptions();
+    
+            $data = $this->dummyVariableService->getById($dummyVariableId, $resourceOptions);
+            $parsedData = $this->parseData($data, $resourceOptions);
+    
+            return $this->response($parsedData);
+        }
+    
+        public function create(Request $request)
+        {
+            $data = $request->all();
+
+            $response = $this->dummyVariableService->create($data);
+
+                if ($response instanceof DummyVariable) {
+                    return [
+                        'status' => true,
+                        'dummyVariable' => $response,
+                    ];
+                } else {
+                    return [
+                        'status' => false,
+                        'message' => $response,
+                    ];
+                }
+            }
+    
+        public function update($dummyVariableId, Request $request)
+        {
+            $data = $request->all();
+
+            $response = $this->dummyVariableService->update($dummyVariableId, $data);
+    
+            if ($response instanceof DummyVariable) {
+                return [
+                    'status' => true,
+                    'dummyVariable' => $response,
+                ];
+            } else {
+                return [
+                    'status' => false,
+                    'message' => $response,
+                ];
+            }
+        }
+    
+        public function delete($dummyVariableId)
+        {
+            return $this->response($this->dummyVariableService->delete($dummyVariableId));
+        }
+}

--- a/infrastructure/Console/stubs/model.stub
+++ b/infrastructure/Console/stubs/model.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DummyClass extends Model
+{
+    //
+}

--- a/infrastructure/Console/stubs/repository.stub
+++ b/infrastructure/Console/stubs/repository.stub
@@ -1,0 +1,51 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyPath\Models\DummyVariable;
+use Infrastructure\Database\Eloquent\Repository;
+
+class DummyClass extends Repository
+{
+    public function getModel()
+    {
+        return new DummyVariable();
+    }
+
+    public function create(array $data)
+    {
+        $dummyVariable = $this->getModel();
+
+        $dummyVariable->fill($data);
+        $dummyVariable->save();
+
+        return $dummyVariable;
+    }
+
+    public function update(DummyVariable $dummyVariable, array $data)
+    {
+        $dummyVariable->fill($data);
+
+        $dummyVariable->save();
+
+        return $dummyVariable;
+    }
+
+    public function getWhereArray(array $clauses, array $options = [])
+    {
+        $query = $this->createBaseBuilder($options);
+
+        $query->where($clauses);
+
+        return $query->get();
+    }
+
+    public function getFirstWhereArray(array $clauses, array $options = [])
+    {
+        $query = $this->createBaseBuilder($options);
+
+        $query->where($clauses);
+
+        return $query->first();
+    }
+}

--- a/infrastructure/Console/stubs/service.stub
+++ b/infrastructure/Console/stubs/service.stub
@@ -1,0 +1,81 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyPath\Repositories\DummyVariableRepository;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Events\Dispatcher;
+
+class DummyClass
+{
+    public $dummyVariableRepository;
+
+    public function __construct(
+        DatabaseManager $database,
+        Dispatcher $dispatcher,
+        DummyVariableRepository $dummyVariableRepository
+    )
+    {
+        $this->database = $database;
+        $this->dispatcher = $dispatcher;
+        $this->dummyVariableRepository = $dummyVariableRepository;
+    }
+
+ public function getAll($options = [], $paginate = null)
+     {
+         return $this->dummyVariableRepository->get($options, $paginate);
+     }
+ 
+     public function getById($dummyVariableId, array $options = [])
+     {
+         $dummyVariable = $this->getRequestedDummyVariable($dummyVariableId);
+ 
+         return $dummyVariable;
+     }
+ 
+     public function getWhere($columns, $values){
+         $dummyVariable = $this->getRequestedDummyVariableByName($columns, $values);
+ 
+         return $dummyVariable;
+     }
+ 
+     public function getWhereArray($clauses){
+         $dummyVariable = $this->getRequestedDummyVariableByArray($clauses);
+ 
+         return $dummyVariable->first();
+     }
+ 
+    public function create($data){
+
+        $dummyVariable = $this->dummyVariableRepository->create($data);
+
+        $dummyVariable->save();
+
+        return $dummyVariable;
+    }
+ 
+     public function update($dummyVariableId, array $data)
+     {
+         $dummyVariable = $this->getRequestedDummyVariable($dummyVariableId);
+ 
+         $this->dummyVariableRepository->update($dummyVariable, $data);
+  
+         return $dummyVariable;
+     }
+ 
+     public function delete($dummyVariableId)
+     {
+         $dummyVariable = $this->getRequestedDummyVariable($dummyVariableId);
+ 
+         $this->dummyVariableRepository->delete($dummyVariableId);
+ 
+         return response("$dummyVariable->id deleted", 200);
+      }
+ 
+     private function getRequestedDummyVariable($dummyVariableId)
+     {
+         $dummyVariable = $this->dummyVariableRepository->getById($dummyVariableId);
+ 
+         return $dummyVariable;
+     }
+}


### PR DESCRIPTION
Allow user to make use of php artisan make:component command to create Controller, Model, Service and Repository files as well as namespace if not exist: e.g. `php artisan make:component Shop Order` would create OrderController, Order, OrderService and OrderRepository under namespace Shop. If namespace Shop not exist, it would be created. 